### PR TITLE
Move all module-specific data on userData to a separate property

### DIFF
--- a/src/app/(editor)/[systemId]/[playbookType]/[playbookId]/page.tsx
+++ b/src/app/(editor)/[systemId]/[playbookType]/[playbookId]/page.tsx
@@ -43,7 +43,8 @@ export default async function Page(props: Props) {
         id: undefined,
         playbookType,
         systemId: systemData.id,
-        playbookId: playbookData.id
+        playbookId: playbookData.id,
+        modules: {}
       }}
     />
   );

--- a/src/components/playbook-modules/renderer.test.tsx
+++ b/src/components/playbook-modules/renderer.test.tsx
@@ -57,7 +57,9 @@ describe('Renderer', () => {
           playbookType: 'scoundrel',
           systemId: 'bitd',
           playbookId: 'cutter',
-          scoundrelName: { text: 'sss' }
+          modules: {
+            scoundrelName: { text: 'sss' }
+          }
         }}
         playbookData={playbookData}
         dispatch={dispatch}
@@ -114,7 +116,8 @@ describe('Renderer', () => {
           id: undefined,
           systemId: 'bitd',
           playbookType: 'scoundrel',
-          playbookId: 'cutter'
+          playbookId: 'cutter',
+          modules: {}
         }}
         playbookData={playbookData}
         dispatch={dispatch}
@@ -150,7 +153,8 @@ describe('Renderer', () => {
           id: undefined,
           systemId: 'bitd',
           playbookType: 'scoundrel',
-          playbookId: 'hound'
+          playbookId: 'hound',
+          modules: {}
         }}
         playbookData={{
           ...playbookData,
@@ -179,7 +183,8 @@ describe('Renderer', () => {
             id: undefined,
             systemId: 'bitd',
             playbookType: 'scoundrel',
-            playbookId: 'cutter'
+            playbookId: 'cutter',
+            modules: {}
           }}
           playbookData={playbookData}
           dispatch={jest.fn()}
@@ -203,7 +208,8 @@ describe('Renderer', () => {
             id: undefined,
             systemId: 'bitd',
             playbookType: 'scoundrel',
-            playbookId: 'cutter'
+            playbookId: 'cutter',
+            modules: {}
           }}
           playbookData={playbookData}
           dispatch={jest.fn()}
@@ -227,7 +233,8 @@ describe('Renderer', () => {
             id: undefined,
             systemId: 'bitd',
             playbookType: 'scoundrel',
-            playbookId: 'cutter'
+            playbookId: 'cutter',
+            modules: {}
           }}
           playbookData={playbookData}
           dispatch={jest.fn()}
@@ -254,7 +261,8 @@ describe('Renderer', () => {
             id: undefined,
             systemId: 'bitd',
             playbookType: 'scoundrel',
-            playbookId: 'cutter'
+            playbookId: 'cutter',
+            modules: {}
           }}
           playbookData={playbookData}
           dispatch={jest.fn()}
@@ -282,7 +290,8 @@ describe('Renderer', () => {
             id: undefined,
             systemId: 'bitd',
             playbookId: 'cutter',
-            playbookType: 'scoundrel'
+            playbookType: 'scoundrel',
+            modules: {}
           }}
           playbookData={playbookData}
           dispatch={jest.fn()}
@@ -310,7 +319,9 @@ describe('Renderer', () => {
             systemId: 'bitd',
             playbookId: 'cutter',
             playbookType: 'scoundrel',
-            scoundrelName: ['oh no']
+            modules: {
+              scoundrelName: ['oh no']
+            }
           }}
           playbookData={playbookData}
           dispatch={jest.fn()}

--- a/src/components/playbook-modules/renderer.tsx
+++ b/src/components/playbook-modules/renderer.tsx
@@ -41,7 +41,7 @@ export default function Renderer(props: Props) {
     }
 
     const moduleDefinition = modules[moduleId];
-    const userValue = userData[moduleId];
+    const userValue = userData.modules[moduleId];
     const playbookProps = playbookData.modules[moduleId];
 
     // up to this point we're just passing arbitrary data for this module around

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -36,9 +36,12 @@ export const savePlaybook = (
     systemId: data.systemId,
     playbookType: data.playbookType,
     playbookId: data.playbookId,
+    modules: {},
     // if there's a name to the character, store that as well
     // so we've got something to show
-    name: data.name ? data.name : `An unnamed ${playbookDefinition.name}`,
+    name: data.modules.name
+      ? data.modules.name
+      : `An unnamed ${playbookDefinition.name}`,
     description: playbookData.name
   };
 

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -7,7 +7,8 @@ describe('validation', () => {
         id: 'asdf',
         systemId: 'asdf',
         playbookType: 'scoundrel',
-        playbookId: 'asdf'
+        playbookId: 'asdf',
+        modules: {}
       };
 
       validateUserData(data);
@@ -18,16 +19,18 @@ describe('validation', () => {
         systemId: 'asdf',
         playbookId: 'asdf',
         playbookType: 'scoundrel',
-        someTextField: { text: 'asdfasdfsadf' },
-        someTracker: { value: 123 },
-        ratings: {
-          actionRatings: {
-            finesse: 2,
-            skirmish: 3,
-            attune: 1
-          },
-          attributeXp: {
-            insight: 5
+        modules: {
+          someTextField: { text: 'asdfasdfsadf' },
+          someTracker: { value: 123 },
+          ratings: {
+            actionRatings: {
+              finesse: 2,
+              skirmish: 3,
+              attune: 1
+            },
+            attributeXp: {
+              insight: 5
+            }
           }
         }
       };
@@ -40,15 +43,17 @@ describe('validation', () => {
         playbookId: 'asdf',
         someTextField: { text: 'asdfasdfsadf' },
         playbookType: 'scoundrel',
-        someTracker: { value: 123 },
-        ratings: {
-          actionRatings: {
-            finesse: 2,
-            skirmish: 3,
-            attune: 1
-          },
-          attributeXp: {
-            insight: 5
+        modules: {
+          someTracker: { value: 123 },
+          ratings: {
+            actionRatings: {
+              finesse: 2,
+              skirmish: 3,
+              attune: 1
+            },
+            attributeXp: {
+              insight: 5
+            }
           }
         }
       };
@@ -64,21 +69,23 @@ describe('validation', () => {
         systemId: 'asdf',
         playbookId: 'asdf',
         playbookType: 'scoundrel',
-        someTextField: { text: 'asdfasdfsadf' },
-        someTracker: { value: 123 },
-        ratings: {
-          actionRatings: {
-            finesse: 2,
-            skirmish: 3,
-            attune: 1
+        modules: {
+          someTextField: { text: 'asdfasdfsadf' },
+          someTracker: { value: 123 },
+          ratings: {
+            actionRatings: {
+              finesse: 2,
+              skirmish: 3,
+              attune: 1
+            },
+            attributeXp: {
+              insight: 5
+            }
           },
-          attributeXp: {
-            insight: 5
-          }
-        },
-        noModule: {
-          willHave: {
-            thisStructure: 'i hope'
+          noModule: {
+            willHave: {
+              thisStructure: 'i hope'
+            }
           }
         }
       };
@@ -93,7 +100,11 @@ describe('validation', () => {
         systemId: 'asdf',
         playbookId: 'asdf',
         playbookType: 'scoundrel',
-        foo: { text: 'all work and no play makes jack a dull boy'.repeat(500) }
+        modules: {
+          foo: {
+            text: 'all work and no play makes jack a dull boy'.repeat(500)
+          }
+        }
       };
 
       expect(() => {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -16,8 +16,12 @@ const unifiedUserValueSchema = userValueSchemas.reduce(
   z.void()
 );
 
-// then add in the usual, more clearly defined properties
-const userDataSchema = UserDataSchema.catchall(unifiedUserValueSchema);
+// add that to the usual, more clearly defined properties
+const userDataSchema = UserDataSchema.merge(
+  z.object({
+    modules: z.record(z.string(), unifiedUserValueSchema)
+  })
+);
 
 export const validateUserData = (userData: UserDataType) => {
   userDataSchema.parse(userData);

--- a/src/reducers/user-data.ts
+++ b/src/reducers/user-data.ts
@@ -9,7 +9,7 @@ export default function userDataReducer(state: UserDataType, action: Action) {
 
   switch (action.type) {
     case 'set_value':
-      state[action.key] = action.value;
+      state.modules[action.key] = action.value;
       break;
     default:
       throw new Error('unexpected action type: ' + action.type);

--- a/src/schemas/user-data.ts
+++ b/src/schemas/user-data.ts
@@ -5,7 +5,8 @@ const UserData = z
     id: z.string().or(z.undefined()),
     systemId: z.string(),
     playbookType: z.string(),
-    playbookId: z.string()
+    playbookId: z.string(),
+    modules: z.record(z.string(), z.any())
   })
   .catchall(z.any());
 

--- a/src/systems/system.test.tsx
+++ b/src/systems/system.test.tsx
@@ -35,7 +35,8 @@ describe('system data check', () => {
                   id: undefined,
                   playbookType,
                   systemId,
-                  playbookId
+                  playbookId,
+                  modules: {}
                 }}
                 dispatch={jest.fn()}
               />


### PR DESCRIPTION
This is to avoid any conflicts between anything on `userData` and any modules. It's unlikely to be a problem, but it's a really good thing to do before people start using this.