### PR TITLE
Fixes for storing saved playbooks in local storage

### DIFF
--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -2,22 +2,26 @@ import { z } from 'zod';
 import {
   UserData as UserDataSchema,
   PlaybookData as PlaybookDataSchema,
-  PlaybookDefinition as PlaybookDefinitionSchema
+  PlaybookDefinition as PlaybookDefinitionSchema,
+  LocalStorageUserData as LocalStorageUserDataSchema
 } from '@/schemas';
 
 const KEY = 'playbooks';
 
 type UserDataType = z.infer<typeof UserDataSchema>;
+type LocalStorageUserDataType = z.infer<typeof LocalStorageUserDataSchema>;
 type PlaybookDefinitionType = z.infer<typeof PlaybookDefinitionSchema>;
 type PlaybookDataType = z.infer<typeof PlaybookDataSchema>;
 
-export const getPlaybooks = (): UserDataType[] => {
+export const getPlaybooks = (): LocalStorageUserDataType[] => {
   const storageValue = window.localStorage.getItem(KEY) || '';
 
-  let playbooks: UserDataType[];
+  let playbooks: LocalStorageUserDataType[];
 
   try {
-    playbooks = z.array(UserDataSchema).parse(JSON.parse(storageValue));
+    playbooks = z
+      .array(LocalStorageUserDataSchema)
+      .parse(JSON.parse(storageValue));
   } catch {
     playbooks = [];
   }
@@ -36,11 +40,10 @@ export const savePlaybook = (
     systemId: data.systemId,
     playbookType: data.playbookType,
     playbookId: data.playbookId,
-    modules: {},
     // if there's a name to the character, store that as well
     // so we've got something to show
-    name: data.modules.name
-      ? data.modules.name
+    name: data.modules.name?.text
+      ? data.modules.name.text
       : `An unnamed ${playbookDefinition.name}`,
     description: playbookData.name
   };

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -2,5 +2,6 @@ export { default as PlaybookData } from './playbook-data';
 export { default as System } from './system';
 export { default as PlaybookDefinition } from './playbook-definition';
 export { default as UserData } from './user-data';
+export { default as LocalStorageUserData } from './local-storage-user-data';
 export { default as BaseModuleDefinition } from './base-module-definition';
 export { default as BasePlaybookProps } from './base-playbook-props';

--- a/src/schemas/local-storage-user-data.ts
+++ b/src/schemas/local-storage-user-data.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+const LocalStorageUserData = z.object({
+  id: z.string().or(z.undefined()),
+  systemId: z.string(),
+  playbookType: z.string(),
+  playbookId: z.string(),
+  name: z.string(),
+  description: z.string()
+});
+
+export default LocalStorageUserData;

--- a/src/schemas/user-data.ts
+++ b/src/schemas/user-data.ts
@@ -1,13 +1,11 @@
 import { z } from 'zod';
 
-const UserData = z
-  .object({
-    id: z.string().or(z.undefined()),
-    systemId: z.string(),
-    playbookType: z.string(),
-    playbookId: z.string(),
-    modules: z.record(z.string(), z.any())
-  })
-  .catchall(z.any());
+const UserData = z.object({
+  id: z.string().or(z.undefined()),
+  systemId: z.string(),
+  playbookType: z.string(),
+  playbookId: z.string(),
+  modules: z.record(z.string(), z.any())
+});
 
 export default UserData;

--- a/tests/integration/local-storage.test.tsx
+++ b/tests/integration/local-storage.test.tsx
@@ -1,0 +1,90 @@
+import Page from '@/app/(selection)/page';
+import { savePlaybook } from '@/lib/local-storage';
+import { render, screen } from '@testing-library/react';
+
+const scoundrel = {
+  id: 'scoundrel',
+  name: 'Scoundrel',
+  modules: {
+    name: {
+      id: 'name',
+      label: 'Name',
+      type: 'textField'
+    }
+  },
+  layout: [['name']],
+  playbooks: ['cutter']
+};
+
+const cutter = {
+  id: 'cutter',
+  modules: {},
+  name: 'Cutter',
+  description: 'something'
+};
+
+describe('showing saved playbooks on homepage', () => {
+  test('no saved playbooks', async () => {
+    render(<Page />);
+
+    const links = await screen.findAllByRole('link');
+    expect(links.length).toEqual(1);
+    expect(links[0].innerHTML).toEqual('New playbook');
+  });
+
+  test('saving a playbook without a name', async () => {
+    savePlaybook(
+      {
+        id: 'adsf',
+        systemId: 'bitd',
+        playbookType: 'scoundrel',
+        playbookId: 'cutter',
+        modules: {}
+      },
+      cutter,
+      scoundrel
+    );
+
+    render(<Page />);
+
+    const links = await screen.findAllByRole('link');
+    expect(links.length).toEqual(2);
+
+    const option = document.querySelectorAll(
+      'a[href="/bitd/scoundrel/cutter/adsf"]'
+    )[0];
+    expect(option).toBeTruthy();
+    expect(option.innerHTML).toContain('An unnamed Scoundrel');
+    expect(option.innerHTML).toContain('Cutter');
+  });
+
+  test('saving a playbook with a name', async () => {
+    savePlaybook(
+      {
+        id: 'adsf',
+        systemId: 'bitd',
+        playbookType: 'scoundrel',
+        playbookId: 'cutter',
+        modules: {
+          name: {
+            text: 'Nigel'
+          }
+        }
+      },
+      cutter,
+      scoundrel
+    );
+
+    render(<Page />);
+
+    const links = await screen.findAllByRole('link');
+    expect(links.length).toEqual(2);
+
+    const option = document.querySelectorAll(
+      'a[href="/bitd/scoundrel/cutter/adsf"]'
+    )[0];
+    expect(option).toBeTruthy();
+    expect(option.innerHTML).toContain('Nigel');
+    expect(option.innerHTML).toContain('Cutter');
+  });
+});


### PR DESCRIPTION
A couple of errors weren't caught by the compiler due to the user data schema's `.catchall()` which I forgot to remove.

Added some integration tests to validate correctness.